### PR TITLE
Set scanning state at start of scan

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -34,6 +34,9 @@ class _AntivirusHomePageState extends State<AntivirusHomePage> {
   HistoryDatabase history = HistoryDatabase();
 
   Future<void> _startScan() async {
+    setState(() {
+      _isScanning = true;
+    });
     List<MockFile> filesToScan = [
       MockFile(filename: "System32.dll", features: [8.2, 1.0, 4.0, 7.8]),
       MockFile(filename: "Secret_Trojan.exe", features: [7.6, 1.0, 3.0, 6.9]),


### PR DESCRIPTION
## Summary
- toggle `_isScanning` when a scan begins so the UI can disable scanning buttons

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68502cc53654832cafe39574d640c3bf